### PR TITLE
introduce openeb dependencies into package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <!-- ROS2 specific dependencies -->
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_auto</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_ros</buildtool_depend>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
   <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
@@ -27,7 +28,24 @@
   <!-- common dependencies -->
   <depend>event_camera_msgs</depend>
   <depend>std_srvs</depend>
-  
+
+  <!-- openeb dependencies -->
+  <buildtool_depend>wget</buildtool_depend>
+  <buildtool_depend>unzip</buildtool_depend>
+  <buildtool_depend>curl</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>hdf5-tools</buildtool_depend>
+  <depend>boost</depend>
+  <depend>libusb-1.0-dev</depend>
+  <depend>libhdf5-dev</depend>
+  <depend>libglew-dev</depend>
+  <depend>libglfw3-dev</depend>
+  <depend>ffmpeg</depend>
+  <depend>libopencv-dev</depend>
+  <depend>libopenscenegraph</depend>
+  <test_depend>gtest</test_depend>
+
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
     <!-- this is crucial else the package will not be registered! -->


### PR DESCRIPTION
the driver currently fails to build on the ROS2 build farm. It complains that OpenEB cannot build due to missing libusb.
The proper fix would probably be to add a package.xml file to the openeb build tree. To avoid polluting the OpenEB source tree, this PR adds the dependencies to the metavision_driver.
