### PR TITLE
add metavision sdk plugin dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(MUST_INSTALL_METAVISION FALSE)
 if(NOT MetavisionSDK_FOUND)
   # must set various variables for OpenEB *before* fetching openEB.
   # CMAKE_ARGS seems to not work for FetchContent_Declare()
-  set(COMPILE_3DVIEW OFF CACHE INTERNAL "Build 3d viewer")
+  # set(COMPILE_3DVIEW OFF CACHE INTERNAL "Build 3d viewer")
   set(COMPILE_PLAYER OFF CACHE INTERNAL "Build player")
   set(COMPILE_PYTHON3_BINDINGS OFF CACHE INTERNAL "build python3 bindings")
   set(UDEV_RULES_SYSTEM_INSTALL OFF CACHE INTERNAL "install udev rules")

--- a/cmake/ROS2.cmake
+++ b/cmake/ROS2.cmake
@@ -98,6 +98,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/)
 
 if(MUST_INSTALL_METAVISION)
+  add_dependencies(driver_ros2 hal_plugins)
   install(DIRECTORY  "${CMAKE_CURRENT_BINARY_DIR}/_deps/metavision-build/lib"
     DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()


### PR DESCRIPTION
This PR adds a dependency on the hal_plugins such that they end up in the install directory. The goal is to allow cameras with non-proprietary plugins (Prophesee eval kits) to work without installation of the metavision SDK.