### PR TITLE
add support for changing the mipi frame period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+launch/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Parameters:
   specifying serial number and look at the log files.
 - ``event_message_time_threshold``: (in seconds) minimum time span of
   events to be aggregated in one ROS event message before message is sent. Defaults to 1ms.
+  In its default setting however the SDK provides packets only every 4ms. To increase SDK
+  callback frequency, tune ``mipi_frame_period`` if available for your sensor.
 - ``event_message_size_threshold``: (in bytes) minimum size of events
   (in bytes) to be aggregated in one ROS event message before message is sent. Defaults to 1MB.
 - ``statistics_print_interval``: time in seconds between statistics printouts.
@@ -142,6 +144,8 @@ Parameters:
 - ``erc_mode``: event rate control mode (Gen4 sensor): ``na``,
   ``disabled``, ``enabled``. Default: ``na``.
 - ``erc_rate``: event rate control rate (Gen4 sensor) events/sec. Default: 100000000.
+- ``mipi_frame_period``:: mipi frame period in usec. Only available on some sensors.
+    Tune this to get faster callback rates from the SDK to the ROS driver. For instance 1008 will give a callback every millisecond. Risk of data corruption when set too low! Default: -1 (not set).
 - ``sync_mode``: Used to synchronize the time stamps across multiple
   cameras (tested for only 2). The cameras must be connected via a
   sync cable, and two separate ROS driver nodes are started, see

--- a/include/metavision_driver/metavision_wrapper.h
+++ b/include/metavision_driver/metavision_wrapper.h
@@ -109,6 +109,7 @@ public:
     ercMode_ = mode;
     ercRate_ = rate;
   }
+  void setMIPIFramePeriod(int usec) { mipiFramePeriod_ = usec; }
 
   bool triggerActive() const
   {
@@ -136,6 +137,7 @@ private:
     const std::string & mode_in, const std::string & mode_out, const int period,
     const double duty_cycle);
   void configureEventRateController(const std::string & mode, const int rate);
+  void configureMIPIFramePeriod(int usec, const std::string & sensorName);
   void printStatistics();
   // ------------ variables
   CallbackHandler * callbackHandler_{0};
@@ -164,6 +166,7 @@ private:
   HardwarePinConfig hardwarePinConfig_;
   std::string ercMode_;
   int ercRate_;
+  int mipiFramePeriod_{-1};
   std::string loggerName_{"driver"};
   std::vector<int> roi_;
   std::string sensorVersion_{"0.0"};

--- a/src/driver_ros1.cpp
+++ b/src/driver_ros1.cpp
@@ -231,6 +231,8 @@ void DriverROS1::configureWrapper(const std::string & name)
     nh_.param<std::string>("erc_mode", "na"),  // Event Rate Controller Mode
     nh_.param<int>("erc_rate", 100000000));    // Event Rate Controller Rate
 
+  wrapper_->setMIPIFramePeriod(nh_.param<int>("mipi_frame_period", -1));
+
   // Get information on external pin configuration per hardware setup
   if (wrapper_->triggerActive()) {
     wrapper_->setHardwarePinConfig(get_hardware_pin_config(nh_, ros::this_node::getName()));

--- a/src/driver_ros2.cpp
+++ b/src/driver_ros2.cpp
@@ -347,6 +347,9 @@ void DriverROS2::configureWrapper(const std::string & name)
   if (wrapper_->triggerActive()) {
     wrapper_->setHardwarePinConfig(get_hardware_pin_config(this));
   }
+  int mipiFramePeriod{-1};
+  this->get_parameter_or("mipi_frame_period", mipiFramePeriod, -1);
+  wrapper_->setMIPIFramePeriod(mipiFramePeriod);
 }
 
 void DriverROS2::rawDataCallback(uint64_t t, const uint8_t * start, const uint8_t * end)


### PR DESCRIPTION
Due to some changes at the SDK level, callbacks from SDK to ROS driver currently occur only every 4ms. This PR allows setting of the mipi_frame_period (in usec) that enables faster callback rates. Setting the period to 1008 (last 4 bits are ignored) will give callbacks about every 1ms.
Currently only supported for the IMX636 sensor.
This PR is related to issue #31 
