### PR TITLE
use openeb_vendor for ROS2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       repo: ${{ github.event.repository.name }}
       vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos
   build_ros2:
-    uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros2_ci.yml@master
+    uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros2_recent_ci.yml@master
     with:
       repo: ${{ github.event.repository.name }}
       vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,41 +16,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(metavision_driver)
 
-include(FetchContent)
-
-find_package(MetavisionSDK COMPONENTS driver QUIET)
-
-# if metavision sdk is not present, download it into the build directory
-set(MUST_INSTALL_METAVISION FALSE)
-
-if(NOT MetavisionSDK_FOUND)
-  message(STATUS "metavision SDK is not installed, must build it")
-  # must set various variables for OpenEB *before* fetching openEB.
-  # CMAKE_ARGS seems to not work for FetchContent_Declare()
-  # set(COMPILE_3DVIEW OFF CACHE INTERNAL "Build 3d viewer")
-  set(COMPILE_PLAYER OFF CACHE INTERNAL "Build player")
-  set(COMPILE_PYTHON3_BINDINGS OFF CACHE INTERNAL "build python3 bindings")
-  set(UDEV_RULES_SYSTEM_INSTALL OFF CACHE INTERNAL "install udev rules")
-
-# The following line must have zero indent. It disables the cmake linter
-# lint_cmake: -readability/wonkycase
-  FetchContent_Declare(
-    metavision
-    GIT_REPOSITORY https://github.com/ros-event-camera/openeb.git
-    GIT_TAG   4.2.0-ros)
-
-  FetchContent_MakeAvailable(metavision)
-  message(STATUS "metavision SDK fetched and made available")
-  # do this to avoid the "install" target being run on the metavision sdk
-  if(IS_DIRECTORY "${metavision_SOURCE_DIR}")
-    set_property(DIRECTORY ${metavision_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
-  endif()
-
-  set(MUST_INSTALL_METAVISION TRUE)
-else()
-  message(STATUS "metavision SDK is installed, not building it")
-endif()
-
 #
 # figure out ROS1 vs ROS2
 #

--- a/cmake/ROS1.cmake
+++ b/cmake/ROS1.cmake
@@ -13,6 +13,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(FetchContent)
+
+find_package(MetavisionSDK COMPONENTS driver QUIET)
+
+# if metavision sdk is not present, download it into the build directory
+set(MUST_INSTALL_METAVISION FALSE)
+
+if(NOT MetavisionSDK_FOUND)
+  message(STATUS "metavision SDK is not installed, must build it")
+  # must set various variables for OpenEB *before* fetching openEB.
+  # CMAKE_ARGS seems to not work for FetchContent_Declare()
+  # set(COMPILE_3DVIEW OFF CACHE INTERNAL "Build 3d viewer")
+  set(COMPILE_PLAYER OFF CACHE INTERNAL "Build player")
+  set(COMPILE_PYTHON3_BINDINGS OFF CACHE INTERNAL "build python3 bindings")
+  set(UDEV_RULES_SYSTEM_INSTALL OFF CACHE INTERNAL "install udev rules")
+
+# The following line must have zero indent. It disables the cmake linter
+# lint_cmake: -readability/wonkycase
+  FetchContent_Declare(
+    metavision
+    GIT_REPOSITORY https://github.com/ros-event-camera/openeb.git
+    GIT_TAG   4.2.0-ros)
+
+  FetchContent_MakeAvailable(metavision)
+  message(STATUS "metavision SDK fetched and made available")
+  # do this to avoid the "install" target being run on the metavision sdk
+  if(IS_DIRECTORY "${metavision_SOURCE_DIR}")
+    set_property(DIRECTORY ${metavision_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
+  endif()
+
+  set(MUST_INSTALL_METAVISION TRUE)
+else()
+  message(STATUS "metavision SDK is installed, not building it")
+endif()
+
+
 #add_compile_options(-Wall -Wextra -pedantic -Werror)
 add_compile_options(-Wall -Wextra -Wpedantic)
 #add_compile_definitions(USING_ROS_1)

--- a/cmake/ROS2.cmake
+++ b/cmake/ROS2.cmake
@@ -28,10 +28,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-# find dependencies
-
-# MetavisionSDK is now found otherwise
-# find_package(MetavisionSDK COMPONENTS driver REQUIRED)
+find_package(MetavisionSDK COMPONENTS driver REQUIRED)
 
 if(MetavisionSDK_VERSION_MAJOR LESS 4)
   add_definitions(-DUSING_METAVISION_3)
@@ -96,12 +93,6 @@ install(DIRECTORY
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}/)
-
-if(MUST_INSTALL_METAVISION)
-  add_dependencies(driver_ros2 hal_plugins)
-  install(DIRECTORY  "${CMAKE_CURRENT_BINARY_DIR}/_deps/metavision-build/lib"
-    DESTINATION ${CMAKE_INSTALL_PREFIX})
-endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -39,21 +39,22 @@
   <depend>std_srvs</depend>
 
   <!-- openeb dependencies -->
-  <buildtool_depend>wget</buildtool_depend>
-  <buildtool_depend>unzip</buildtool_depend>
-  <buildtool_depend>curl</buildtool_depend>
-  <buildtool_depend>git</buildtool_depend>
-  <buildtool_depend>cmake</buildtool_depend>
-  <buildtool_depend>hdf5-tools</buildtool_depend>
-  <depend>boost</depend>
-  <depend>libusb-1.0-dev</depend>
-  <depend>libhdf5-dev</depend>
-  <depend>libglew-dev</depend>
-  <depend>libglfw3-dev</depend>
-  <depend>ffmpeg</depend>
-  <depend>libopencv-dev</depend>
-  <depend>libopenscenegraph</depend>
-  <test_depend>gtest</test_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">wget</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">unzip</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">curl</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">git</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">hdf5-tools</buildtool_depend>
+  <depend condition="$ROS_VERSION == 2">openeb</depend>
+  <depend condition="$ROS_VERSION == 1">boost</depend>
+  <depend condition="$ROS_VERSION == 1">libusb-1.0-dev</depend>
+  <depend condition="$ROS_VERSION == 1">libhdf5-dev</depend>
+  <depend condition="$ROS_VERSION == 1">libglew-dev</depend>
+  <depend condition="$ROS_VERSION == 1">libglfw3-dev</depend>
+  <depend condition="$ROS_VERSION == 1">ffmpeg</depend>
+  <depend condition="$ROS_VERSION == 1">libopencv-dev</depend>
+  <depend condition="$ROS_VERSION == 1">libopenscenegraph</depend>
+  <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml"/>

--- a/package.xml
+++ b/package.xml
@@ -45,7 +45,7 @@
   <buildtool_depend condition="$ROS_VERSION == 1">git</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 1">cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 1">hdf5-tools</buildtool_depend>
-  <depend condition="$ROS_VERSION == 2">openeb</depend>
+  <depend condition="$ROS_VERSION == 2">openeb_vendor</depend>
   <depend condition="$ROS_VERSION == 1">boost</depend>
   <depend condition="$ROS_VERSION == 1">libusb-1.0-dev</depend>
   <depend condition="$ROS_VERSION == 1">libhdf5-dev</depend>


### PR DESCRIPTION
For ROS2, this PR switches to using the openeb library as an external package. Maintaining openeb as a ROS vendor package is cleaner and follows common practice of other ROS2 projects.
Doing this only for ROS2 since the ROS1 version is not released as a package.
