### PR TITLE
set serial parameter type to string

### DIFF
--- a/launch/driver_node.launch
+++ b/launch/driver_node.launch
@@ -21,7 +21,7 @@
     <!--- use a time of zero to force immediate sending of trigger
 	message, else there will always be at least 2 trigger events
 	per message -->
-    <param name="serial" value="$(arg serial)"/>
+    <param name="serial" value="$(arg serial)" type="string"/>
     <param name="trigger_out_mode" value="$(arg trigger_out_mode)"/>
     <!-- units of trigger_out_period is usec -->
     <param name="trigger_out_period" value="$(arg trigger_out_period)"/>

--- a/launch/recording_driver.launch
+++ b/launch/recording_driver.launch
@@ -22,6 +22,6 @@
     <param name="statistics_print_interval" value="1.0"/>
     <!-- from where to load the bias file (if any)  -->
     <param name="bias_file" value="$(arg bias_file)"/>
-    <param name="serial" value="$(arg serial)"/>
+    <param name="serial" value="$(arg serial)" type="string"/>
   </node>
 </launch>

--- a/launch/stereo_driver_node.launch
+++ b/launch/stereo_driver_node.launch
@@ -8,7 +8,7 @@
 	output="screen">
     <param name="frame_id" value="event_cam_0"/>
     <param name="sync_mode" value="primary"/>
-    <param name="serial" value="$(arg serial_cam_0)"/>
+    <param name="serial" value="$(arg serial_cam_0)" type="string"/>
     <param name="event_message_time_threshold" value="0.0001"/>
     <!-- time interval between printout of rate statistics -->
     <param name="statistics_print_interval" value="2.0"/>
@@ -25,7 +25,7 @@
 	output="screen">
     <param name="frame_id" value="event_cam_1"/>
     <param name="sync_mode" value="secondary"/>
-    <param name="serial" value="$(arg serial_cam_1)"/>
+    <param name="serial" value="$(arg serial_cam_1)" type="string"/>
     <param name="event_message_time_threshold" value="0.0001"/>
     <!-- time interval between printout of rate statistics -->
     <param name="statistics_print_interval" value="2.0"/>


### PR DESCRIPTION
Currently the ROS1 driver does not handle the specified serial number correctly because it is converted to an int,
see issue #47 
The simplest way to work around this is to explicitly set the parameter type to string in the launch file.
