### PR TITLE
trail filter: fixed unintialized variable bug and handle gen3 cams

### DIFF
--- a/include/metavision_driver/metavision_wrapper.h
+++ b/include/metavision_driver/metavision_wrapper.h
@@ -66,9 +66,9 @@ public:
 
   struct TrailFilter
   {
-    bool enabled;
-    std::string type;
-    uint32_t threshold;
+    bool enabled{false};
+    std::string type{"INVALID"};
+    uint32_t threshold{5000};
   };
 
   typedef std::map<std::string, std::map<std::string, int>> HardwarePinConfig;

--- a/launch/driver_node.launch.py
+++ b/launch/driver_node.launch.py
@@ -51,7 +51,7 @@ def launch_setup(context, *args, **kwargs):
                 "erc_mode": "enabled",
                 "erc_rate": 100000000,
                 "trail_filter": False,
-                "trail_filter_type": "stc_trail_cut",
+                "trail_filter_type": "stc_cut_trail",
                 "trail_filter_threshold": 5000,
                 # 'roi': [0, 0, 100, 100],
                 # valid: 'external', 'loopback', 'disabled'

--- a/src/metavision_wrapper.cpp
+++ b/src/metavision_wrapper.cpp
@@ -458,19 +458,24 @@ void MetavisionWrapper::activateTrailFilter()
   Metavision::I_EventTrailFilterModule * i_trail_filter =
     cam_.get_device().get_facility<Metavision::I_EventTrailFilterModule>();
 
-  const auto it = trailFilterMap.find(trailFilter_.type);
-  if (it == trailFilterMap.end()) {
-    BOMB_OUT_CERR("unknown trail filter type " << trailFilter_.type);
+  if (!i_trail_filter) {
+    LOG_WARN_NAMED("this camera does not support trail filtering!");
+    return;
   }
-
-  // Set filter type
-  if (!i_trail_filter->set_type(it->second)) {
-    LOG_WARN_NAMED("cannot set type of trail filter!")
+  if (trailFilter_.enabled) {
+    const auto it = trailFilterMap.find(trailFilter_.type);
+    if (it == trailFilterMap.end()) {
+      LOG_WARN_NAMED("unknown trail filter type: " << trailFilter_.type);
+    } else {
+      // Set filter type
+      if (!i_trail_filter->set_type(it->second)) {
+        LOG_WARN_NAMED("cannot set type of trail filter!")
+      }
+      if (!i_trail_filter->set_threshold(trailFilter_.threshold)) {
+        LOG_WARN_NAMED("cannot set threshold of trail filter!")
+      }
+    }
   }
-  if (!i_trail_filter->set_threshold(trailFilter_.threshold)) {
-    LOG_WARN_NAMED("cannot set threshold of trail filter!")
-  }
-
   i_trail_filter->enable(trailFilter_.enabled);
 }
 


### PR DESCRIPTION
 - Bug fixed: if trail filter parameter was set to false, the trail filter enabled variable was never set, and hence was left uninitialized.
 - Also: handle Gen3 cameras gracefully, which do not support trail filtering.
