### PR TITLE
Set event format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,11 @@ on:
     branches: [ master]
 
 jobs:
-  build_ros1:
-    uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros1_ci.yml@master
-    with:
-      repo: ${{ github.event.repository.name }}
-      vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos
+  # build_ros1:
+  #   uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros1_ci.yml@master
+  #   with:
+  #     repo: ${{ github.event.repository.name }}
+  #    vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos
   build_ros2:
     uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros2_recent_ci.yml@master
     with:

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Parameters:
 - ``serial``: specifies serial number of camera to open (useful for
   stereo). To learn serial number format first start driver without
   specifying serial number and look at the log files.
+- ``encoding``: event data format (ROS2 only). This will configure the event data
+  format of the camera. Default: ``evt3`` (Note: lower case!).
+  Valid is only ``evt3`` at the moment because there is no decoder for ``evt2`` and ``evt21``
+  implemented in the event\_camera\_codecs package.
 - ``event_message_time_threshold``: (in seconds) minimum time span of
   events to be aggregated in one ROS event message before message is sent. Defaults to 1ms.
   In its default setting however the SDK provides packets only every 4ms. To increase SDK

--- a/include/metavision_driver/metavision_wrapper.h
+++ b/include/metavision_driver/metavision_wrapper.h
@@ -108,6 +108,7 @@ public:
   bool startCamera(CallbackHandler * h);
   void setLoggerName(const std::string & s) { loggerName_ = s; }
   void setStatisticsInterval(double sec) { statsInterval_ = sec; }
+  void setEncodingFormat(const std::string & f) { encodingFormat_ = f; }
 
   // ROI is a double vector with length multiple of 4:
   // (x_top_1, y_top_1, width_1, height_1,
@@ -185,7 +186,7 @@ private:
   int mipiFramePeriod_{-1};
   std::string loggerName_{"driver"};
   std::vector<int> roi_;
-  std::string encodingFormat_{"unknown"};
+  std::string encodingFormat_{"EVT3"};
   std::string sensorVersion_{"0.0"};
   // --  related to statistics
   double statsInterval_{2.0};  // time between printouts

--- a/launch/driver_node.launch.py
+++ b/launch/driver_node.launch.py
@@ -50,6 +50,7 @@ def launch_setup(context, *args, **kwargs):
                 "serial": LaunchConfig("serial"),
                 "erc_mode": "enabled",
                 "erc_rate": 100000000,
+                "encoding": "evt21",
                 "trail_filter": False,
                 "trail_filter_type": "stc_cut_trail",
                 "trail_filter_threshold": 5000,
@@ -72,8 +73,12 @@ def generate_launch_description():
     """Create simple node by calling opaque function."""
     return launch.LaunchDescription(
         [
-            LaunchArg("camera_name", default_value=["event_camera"], description="camera name"),
-            LaunchArg("serial", default_value=[""], description="serial number of camera"),
+            LaunchArg(
+                "camera_name", default_value=["event_camera"], description="camera name"
+            ),
+            LaunchArg(
+                "serial", default_value=[""], description="serial number of camera"
+            ),
             OpaqueFunction(function=launch_setup),
         ]
     )

--- a/src/driver_ros1.cpp
+++ b/src/driver_ros1.cpp
@@ -38,7 +38,7 @@ DriverROS1::DriverROS1(ros::NodeHandle & nh) : nh_(nh)
     static_cast<size_t>(std::abs(nh_.param<int>("event_message_size_threshold", 1024 * 1024)));
 
   eventPub_ = nh_.advertise<EventPacketMsg>("events", nh_.param<int>("send_queue_size", 1000));
-
+  wrapper_->setEncodingFormat(encoding_);
   if (wrapper_->getSyncMode() == "primary") {
     // defer starting the primary until the secondary is up
     ros::ServiceClient client = nh_.serviceClient<Trigger>("ready");

--- a/src/driver_ros2.cpp
+++ b/src/driver_ros2.cpp
@@ -37,8 +37,8 @@ DriverROS2::DriverROS2(const rclcpp::NodeOptions & options)
   configureWrapper(get_name());
 
   this->get_parameter_or("encoding", encoding_, std::string("evt3"));
-  if (encoding_ != "evt3") {
-    LOG_ERROR("invalid encoding: " << encoding_);
+  if (encoding_ != "evt3") {  // Other encodings have no support yet from event_camera_codecs.
+    LOG_ERROR("unsupported encoding: " << encoding_);
     throw std::runtime_error("invalid encoding!");
   }
   double mtt;
@@ -226,6 +226,7 @@ void DriverROS2::start()
   wrapper_->setStatisticsInterval(printInterval);
   std::string biasFile;
   this->get_parameter_or("bias_file", biasFile, std::string(""));
+  wrapper_->setEncodingFormat(encoding_);
   if (!wrapper_->initialize(useMT, biasFile)) {
     LOG_ERROR("driver initialization failed!");
     throw std::runtime_error("driver initialization failed!");

--- a/src/metavision_wrapper.cpp
+++ b/src/metavision_wrapper.cpp
@@ -81,6 +81,13 @@ static std::string to_lower(const std::string upper)
   return (lower);
 }
 
+static std::string to_upper(const std::string lower)
+{
+  std::string upper(lower);
+  std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+  return (upper);
+}
+
 MetavisionWrapper::MetavisionWrapper(const std::string & loggerName)
 {
   setLoggerName(loggerName);
@@ -311,6 +318,9 @@ void MetavisionWrapper::configureEventRateController(
 
 bool MetavisionWrapper::initializeCamera()
 {
+  Metavision::DeviceConfig deviceConfig;
+  LOG_INFO_NAMED("setting encoding format: " << encodingFormat_);
+  deviceConfig.set_format(to_upper(encodingFormat_));
   const int num_tries = 5;
   for (int i = 0; i < num_tries; i++) {
     try {
@@ -320,9 +330,9 @@ bool MetavisionWrapper::initializeCamera()
         cam_ = Metavision::Camera::from_file(fromFile_, cfg);
       } else {
         if (!serialNumber_.empty()) {
-          cam_ = Metavision::Camera::from_serial(serialNumber_);
+          cam_ = Metavision::Camera::from_serial(serialNumber_, deviceConfig);
         } else {
-          cam_ = Metavision::Camera::from_first_available();
+          cam_ = Metavision::Camera::from_first_available(deviceConfig);
         }
       }
       break;  // were able to open the camera, exit the for loop


### PR DESCRIPTION
The GenX320 cameras produce EVT21 by default. This PR will set the encoding on the camera explicitly to EVT3.
